### PR TITLE
Log playback reason in Asterisk handler

### DIFF
--- a/app/backend/asterisk/stasis_handler.py
+++ b/app/backend/asterisk/stasis_handler.py
@@ -440,12 +440,15 @@ class AsteriskAIHandler:
         playback = event.get('playback', {})
         playback_id = playback.get('id')
         target_uri = playback.get('target_uri', '')
+        reason = playback.get('reason') or playback.get('cause')
 
         # Извлекаем channel_id из target_uri (формат: channel:1234567890.123)
         if target_uri.startswith('channel:'):
             channel_id = target_uri.replace('channel:', '')
 
-            logger.info(f"🔊 Проигрывание завершено: {playback_id} на канале {channel_id}")
+            logger.info(
+                f"🔊 Проигрывание завершено: {playback_id} на канале {channel_id}, причина: {reason}"
+            )
 
             if channel_id in self.active_calls:
                 call_data = self.active_calls[channel_id]


### PR DESCRIPTION
## Summary
- log playback completion reason or cause along with playback and channel identifiers

## Testing
- `pytest` *(fails: async def functions are not natively supported)*
- `pip install pytest pytest-asyncio` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bad73efa3c8324969d728ec77326ad