### PR TITLE
Use ARI client for audio playback and add sequence test

### DIFF
--- a/app/backend/services/parallel_tts.py
+++ b/app/backend/services/parallel_tts.py
@@ -159,23 +159,20 @@ class ParallelTTSProcessor:
         
         try:
             play_start = time.time()
-            
-            # В реальной реализации здесь будет вызов ARI для воспроизведения
-            # success = await self.ari_client.play_audio_data(channel_id, item["audio_data"])
-            
-            # ЗАГЛУШКА: Симулируем воспроизведение
-            await asyncio.sleep(0.1)  # Симулируем время воспроизведения
-            success = True
-            
+
+            success = await self.ari_client.play_audio_data(channel_id, item["audio_data"])
+
             play_time = time.time() - play_start
-            
+
             if success:
-                logger.info(f"🔊 Played chunk {item['chunk_num']}: {play_time:.2f}s - '{item['text'][:30]}...'")
+                logger.info(
+                    f"🔊 Played chunk {item['chunk_num']}: {play_time:.2f}s - '{item['text'][:30]}...'"
+                )
                 return True
             else:
                 logger.error(f"❌ Failed to play chunk {item['chunk_num']}")
                 return False
-                
+
         except Exception as e:
             logger.error(f"❌ Audio playback error: {e}")
             return False

--- a/tests/test_parallel_tts.py
+++ b/tests/test_parallel_tts.py
@@ -1,0 +1,45 @@
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.backend.services.parallel_tts import ParallelTTSProcessor
+
+
+class DummyGrpcTTS:
+    async def synthesize_chunk_fast(self, text: str) -> bytes:
+        return text.encode()
+
+
+class RecordingARIClient:
+    def __init__(self):
+        self.played = []
+
+    async def play_audio_data(self, channel_id: str, audio_data: bytes) -> bool:
+        self.played.append(audio_data.decode())
+        return True
+
+
+def test_chunks_play_in_order():
+    async def run():
+        grpc = DummyGrpcTTS()
+        ari = RecordingARIClient()
+        processor = ParallelTTSProcessor(grpc, ari)
+        channel = "test_channel"
+
+        await processor.process_chunk_immediate(
+            channel, {"chunk_number": 0, "text": "first", "is_first": True}
+        )
+        await processor.process_chunk_immediate(channel, {"chunk_number": 1, "text": "second"})
+
+        await asyncio.gather(*processor.tts_tasks[channel])
+
+        while processor.playback_busy[channel] or processor.playback_queues[channel]:
+            await asyncio.sleep(0.01)
+
+        assert ari.played == ["first", "second"]
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- replace async sleep stub with ARI client's play method and error handling
- add test to ensure audio chunks play sequentially

## Testing
- `pytest tests/test_parallel_tts.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1578d1e40832483d84766bb1aea71