### PR TITLE
Remove unused temporary file in HTTP TTS fallback

### DIFF
--- a/app/backend/services/tts_adapter.py
+++ b/app/backend/services/tts_adapter.py
@@ -88,24 +88,19 @@ class TTSAdapter:
         """Fallback на HTTP TTS"""
         try:
             # Используем существующий HTTP TTS сервис
-            # Создаем временный файл для получения аудио данных
-            import tempfile
             import os
-            
-            with tempfile.NamedTemporaryFile(suffix='.wav', delete=False) as temp_file:
-                temp_path = temp_file.name
-            
+
             # Генерируем аудио через HTTP TTS
             result = await self.http_tts.text_to_speech(text, "fallback")
-            
+
             if result:
                 # Читаем сгенерированный файл
                 wav_path = os.path.join(self.http_tts.asterisk_sounds_dir, f"{result}.wav")
                 if os.path.exists(wav_path):
                     with open(wav_path, 'rb') as f:
                         audio_data = f.read()
-                    
-                    # Удаляем временный файл
+
+                    # Удаляем файл после чтения
                     os.unlink(wav_path)
                     return audio_data
             


### PR DESCRIPTION
## Summary
- remove unnecessary temporary file creation in HTTP fallback
- keep deleting generated WAV files after reading

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c159b0b3188324a0ddf8b1fbe69be7