### PR TITLE
Ensure Yandex gRPC TTS outputs 8kHz audio

### DIFF
--- a/app/backend/services/yandex_grpc_tts.py
+++ b/app/backend/services/yandex_grpc_tts.py
@@ -120,8 +120,9 @@ class YandexGrpcTTS:
             request = tts_pb2.UtteranceSynthesisRequest(
                 text=text,
                 output_audio_spec=tts_pb2.AudioFormatOptions(
-                    container_audio=tts_pb2.ContainerAudio(
-                        container_audio_type=tts_pb2.ContainerAudio.ContainerAudioType.WAV
+                    raw_audio=tts_pb2.RawAudio(
+                        audio_encoding=tts_pb2.RawAudio.AudioEncoding.LINEAR16_PCM,
+                        sample_rate_hertz=8000,
                     )
                 ),
                 # КРИТИЧНО: настройки для минимальной латентности


### PR DESCRIPTION
## Summary
- Request raw LINEAR16_PCM audio at 8kHz from Yandex gRPC TTS
- Validate or convert audio to 8kHz WAV before playback

## Testing
- `python -m py_compile app/backend/services/yandex_grpc_tts.py app/backend/asterisk/stasis_handler_optimized.py`
- `sox --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c159a77f808324b52ccd21ebf9dc96