### PR TITLE
feat: switch optimized TTS to adapter

### DIFF
--- a/app/backend/asterisk/stasis_handler_optimized.py
+++ b/app/backend/asterisk/stasis_handler_optimized.py
@@ -404,39 +404,10 @@ class OptimizedAsteriskAIHandler:
                 # Fallback на старый метод
                 await self.speak_queued(channel_id, text)
                 return
-            
-            # ВРЕМЕННО: Используем оригинальный TTS для тестирования
-            # TODO: Вернуться к TTS Adapter после исправления формата
-            logger.info("🔄 ВРЕМЕННО: Используем оригинальный TTS для тестирования")
-            
-            # Используем оригинальный TTS сервис
-            from app.backend.services.yandex_tts_service import get_yandex_tts_service
-            original_tts = get_yandex_tts_service()
-            
-            # Создаем файл через оригинальный TTS
-            timestamp = datetime.now().strftime('%H%M%S%f')[:-3]
-            audio_filename = f"stream_{channel_id}_{timestamp}"
-            sound_filename = await original_tts.text_to_speech(text, audio_filename)
-            
-            if sound_filename:
-                # Воспроизводим через ARI (как в оригинале)
-                async with AsteriskARIClient() as ari:
-                    playback_id = await ari.play_sound(channel_id, sound_filename, lang=None)
-                    
-                    if playback_id:
-                        # Обновляем данные канала
-                        if channel_id in self.active_calls:
-                            call_data = self.active_calls[channel_id]
-                            call_data["current_playback"] = playback_id
-                            call_data["is_speaking"] = True
-                            call_data["last_speak_started_at"] = int(time.time() * 1000)
-                        
-                        logger.info(f"✅ Аудио воспроизводится через ARI: {playback_id}")
-                    else:
-                        logger.warning("⚠️ ARI playback не удался")
-            else:
-                logger.warning("Оригинальный TTS не вернул имя файла")
-                
+            # Синтезируем речь через адаптер TTS и воспроизводим
+            audio_data = await self.tts_adapter.synthesize(text)
+            await self._play_audio_data(channel_id, audio_data)
+
         except Exception as e:
             logger.error(f"❌ Optimized speak error: {e}")
             # Fallback на старый метод


### PR DESCRIPTION
## Summary
- use TTS adapter for optimized speech instead of temporary original TTS

## Testing
- `pytest`
- `python app/backend/asterisk/stasis_handler_optimized.py` *(fails: ModuleNotFoundError: No module named 'langchain_chroma')*


------
https://chatgpt.com/codex/tasks/task_e_68c159a268e08324aeb487db78669f0e