### PR TITLE
Use aiohttp for asynchronous Yandex TTS requests

### DIFF
--- a/app/backend/services/yandex_grpc_tts.py
+++ b/app/backend/services/yandex_grpc_tts.py
@@ -11,6 +11,8 @@ import time
 import logging
 from typing import Optional
 
+import aiohttp
+
 # Добавляем путь к gRPC файлам
 current_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(current_dir)
@@ -74,28 +76,29 @@ class YandexGrpcTTS:
             logger.error(f"❌ gRPC TTS initialization failed: {e}")
             raise
     
-    def _get_fresh_iam_token(self) -> str:
+    async def _get_fresh_iam_token(self) -> str:
         """Получение свежего IAM токена с кешированием"""
-        import requests
-        
+
         # Проверяем, не истек ли токен (12 часов = 43200 сек, обновляем за час до истечения)
         if self.iam_token and time.time() < (self.iam_token_expires - 3600):
             return self.iam_token
-        
+
         url = "https://iam.api.cloud.yandex.net/iam/v1/tokens"
         headers = {"Content-Type": "application/json"}
         data = {"yandexPassportOauthToken": self.api_key}
-        
+
         try:
-            response = requests.post(url, headers=headers, json=data, timeout=5)
-            response.raise_for_status()
-            
-            token_data = response.json()
+            timeout = aiohttp.ClientTimeout(total=5)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.post(url, headers=headers, json=data) as response:
+                    response.raise_for_status()
+                    token_data = await response.json()
+
             self.iam_token = token_data["iamToken"]
-            
+
             # Токен действует 12 часов
             self.iam_token_expires = time.time() + 43200
-            
+
             logger.info("🔑 IAM токен обновлен")
             return self.iam_token
         except Exception as e:
@@ -112,7 +115,7 @@ class YandexGrpcTTS:
         try:
             # Метаданные аутентификации
             metadata = [
-                ('authorization', f'Bearer {self._get_fresh_iam_token()}'),
+                ('authorization', f'Bearer {await self._get_fresh_iam_token()}'),
                 ('x-folder-id', self.folder_id)
             ]
             


### PR DESCRIPTION
## Summary
- replace blocking requests with aiohttp in Yandex TTS services
- fetch IAM tokens and synthesize HTTP TTS asynchronously
- run heavy subprocesses via `asyncio.to_thread`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c15cf66d888324b8adeeb367fc7519