### PR TITLE
Use synthesize method in ParallelTTSProcessor

### DIFF
--- a/app/backend/asterisk/stasis_handler_optimized.py
+++ b/app/backend/asterisk/stasis_handler_optimized.py
@@ -105,7 +105,11 @@ class OptimizedAsteriskAIHandler:
             
             # 4. Parallel TTS Processor
             ari_client = AsteriskARIClient()
-            self.parallel_tts = ParallelTTSProcessor(self.tts_adapter, ari_client)
+            # передаем адаптер с методом synthesize
+            self.parallel_tts = ParallelTTSProcessor(
+                grpc_tts=self.tts_adapter,
+                ari_client=ari_client
+            )
             
             logger.info("✅ Все сервисы оптимизации инициализированы")
             

--- a/app/backend/services/parallel_tts.py
+++ b/app/backend/services/parallel_tts.py
@@ -84,7 +84,7 @@ class ParallelTTSProcessor:
         
         try:
             # gRPC TTS (параллельно с другими чанками)
-            audio_data = await self.grpc_tts.synthesize_chunk_fast(text)
+            audio_data = await self.grpc_tts.synthesize(text)
             tts_time = time.time() - tts_start
             
             logger.info(f"✅ TTS done for chunk {chunk_num}: {tts_time:.2f}s")


### PR DESCRIPTION
## Summary
- switch ParallelTTSProcessor to call generic `synthesize`
- ensure stasis handler passes TTSAdapter with `synthesize` method

## Testing
- `python - <<'PY'
import asyncio, logging
from app.backend.services.parallel_tts import ParallelTTSProcessor

logging.basicConfig(level=logging.INFO)

class DummyTTS:
    async def synthesize(self, text):
        await asyncio.sleep(0.05)
        return text.encode()

async def run_test():
    tts = DummyTTS()
    processor = ParallelTTSProcessor(tts, ari_client=None)
    await processor.process_chunk_immediate('chan', {'chunk_number':1,'text':'first','is_first':True})
    await processor.process_chunk_immediate('chan', {'chunk_number':2,'text':'second','is_first':False})
    await processor.process_chunk_immediate('chan', {'chunk_number':3,'text':'third','is_first':False})
    await asyncio.gather(*processor.tts_tasks['chan'])
    while processor.playback_busy['chan'] or processor.playback_queues['chan']:
        await asyncio.sleep(0.05)

asyncio.run(run_test())
PY`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c15cf9ec5c8324a409c9766c63c1e3